### PR TITLE
Feature/redis ranking and async

### DIFF
--- a/docs/redis-ranking/design.md
+++ b/docs/redis-ranking/design.md
@@ -1,0 +1,55 @@
+# Redis 기반 상품 주문 랭킹 설계
+
+## 1. Flow
+
+```mermaid
+flowchart TD
+  subgraph 랭킹 조회 [📊 랭킹 조회 Flow]
+    D[랭킹 조회 요청] --> E[ZREVRANGE 조회]
+    E --> F[상품 ID + score 반환]
+  end
+
+  subgraph 주문 시 처리 [🛒 Score 증가 Flow]
+    A[주문 발생] --> B[ZINCRBY - 상품 score 증가]
+    B --> C[ZINCRBY - 일/주/월 Sorted Set 갱신]
+  end
+```
+
+### 1.1 Sorted Set Add
+
+- **주문 시:**
+
+  - Redis의 Sorted Set(`ZINCRBY`)을 사용하여 상품 ID를 key로, 주문 수를 score로 저장
+  - 예시: `ZINCRBY product:order:daily:20250101 1 <product_id>`
+
+### 1.2 Get Rank (with Scores)
+
+- 랭킹 조회 시 `ZREVRANGE` 명령어를 사용하여 score와 함께 반환
+- 예시: `ZREVRANGE product:order:daily:20250101 0 9 WITHSCORES` (상위 10개)
+
+### 1.3 기간별 랭킹
+
+- **일별:** `product:order:daily:<yyyyMMdd>`
+- **주간별:** `product:order:weekly:<yyyyWW>`
+- **월별:** `product:order:monthly:<yyyyMM>`
+- 주문 발생 시 해당 기간의 Sorted Set에 동시에 반영
+
+### 1.4 동일 점수 처리
+
+- Redis Sorted Set은 score가 같을 경우 lexicographical order(사전순)로 정렬
+- 동일 점수일 때 상품 ID 기준 오름차순 정렬됨
+- 필요 시 tie-breaker(예: 최근 주문 시간) 추가 고려
+
+## 2. 참고 명령어
+
+- `ZADD`, `ZINCRBY`, `ZRANGE`, `ZREVRANGE`, `ZREVRANK`, `ZCARD`, `ZREM`
+
+## 3. 예시
+
+```shell
+# 주문 발생 시
+ZINCRBY product:order:daily:20240601 1 12345
+
+# 일별 랭킹 조회
+ZREVRANGE product:order:daily:20240601 0 9 WITHSCORES
+```

--- a/src/main/java/kr/hhplus/be/server/coupon/Coupon.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/Coupon.java
@@ -1,0 +1,54 @@
+package kr.hhplus.be.server.coupon;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Table(name = "coupons")
+@Getter
+public class Coupon {
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @Column(nullable = false)
+  private String code;
+  @Column(nullable = false)
+  private String name;
+  @Column(nullable = false)
+  private BigDecimal discountAmount;
+  @Column(nullable = false)
+  private int totalQuantity;
+  @Column(nullable = false)
+  private int issuedQuantity;
+  @Column(nullable = false)
+  private LocalDateTime validFrom;
+  @Column(nullable = false)
+  private LocalDateTime validTo;
+
+  protected Coupon() {}
+
+  public Coupon(String code, String name, BigDecimal discountAmount, int totalQuantity, LocalDateTime validFrom, LocalDateTime validTo) {
+    this.code = code;
+    this.name = name;
+    this.discountAmount = discountAmount;
+    this.totalQuantity = totalQuantity;
+    this.issuedQuantity = 0;
+    this.validFrom = validFrom;
+    this.validTo = validTo;
+  }
+
+  public int getCurrentQuantity() {
+    return this.totalQuantity - issuedQuantity;
+  }
+
+  public void issue() {
+    this.issuedQuantity += 1;
+  }
+}

--- a/src/main/java/kr/hhplus/be/server/coupon/CouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/CouponRepository.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.coupon;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT c FROM Coupon c WHERE c.id = :id")
+  Optional<Coupon> findByIdForUpdate(@Param("id") Long id);
+}

--- a/src/main/java/kr/hhplus/be/server/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/CouponService.java
@@ -1,0 +1,49 @@
+package kr.hhplus.be.server.coupon;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import kr.hhplus.be.server.usercoupon.UserCouponService;
+
+/**
+ * 쿠폰 서비스
+ * 
+ * 쿠폰 발급 로직을 처리하는 서비스입니다.
+ */
+@Service
+public class CouponService {
+  private final CouponRepository couponRepository;
+  private final UserCouponService userCouponService;
+
+  public CouponService(CouponRepository couponRepository, UserCouponService userCouponService) {
+    this.couponRepository = couponRepository;
+    this.userCouponService = userCouponService;
+  }
+  
+  /**
+   * 쿠폰을 발급합니다.
+   * 
+   * @param userId 발급받는 사용자 ID
+   * @param couponId 발급할 쿠폰 ID
+   * @throws IllegalArgumentException 쿠폰이 존재하지 않을 경우
+   * @throws IllegalStateException 쿠폰이 이미 발급 마감된 경우
+   */
+  @Transactional
+  public void issueCoupon(Long userId, Long couponId) {
+    Coupon coupon = couponRepository.findByIdForUpdate(couponId)
+    .orElseThrow(() -> new IllegalArgumentException("찾을 수 없는 쿠폰입니다."));
+
+    if (coupon.getCurrentQuantity() <= 0) {
+      throw new IllegalStateException("발급 마감된 쿠폰입니다.");
+    }
+
+    coupon.issue();
+    couponRepository.save(coupon);
+
+    userCouponService.issueUserCoupon(
+      userId, 
+      couponId, 
+      coupon.getValidTo()
+    );
+  }
+}

--- a/src/main/java/kr/hhplus/be/server/order/usecase/ProductOrderRankingService.java
+++ b/src/main/java/kr/hhplus/be/server/order/usecase/ProductOrderRankingService.java
@@ -1,0 +1,96 @@
+package kr.hhplus.be.server.order.usecase;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+import java.util.Set;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 레디스를 사용해 가장 많이 주문된 제품의 순위를 일/주/월 단위로 매기는 서비스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductOrderRankingService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * 제품 주문 점수를 증가시키고, 일/주/월 단위로 순위를 매깁니다.
+     * 
+     * @param productId 제품 ID
+     */
+    public void increaseProductScore(String productId) {
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+
+        // 일/주/월별로 각각 증가
+        zSetOps.incrementScore(getTodayKey(), productId, 1.0);
+        zSetOps.incrementScore(getCurrentWeekKey(), productId, 1.0);
+        zSetOps.incrementScore(getCurrentMonthKey(), productId, 1.0);
+
+        // 키별 TTL 설정: 일간은 30일, 주간은 12주, 월간은 12개월 유지
+        setTTL(getTodayKey(), Duration.ofDays(30));
+        setTTL(getCurrentWeekKey(), Duration.ofDays(90));
+        setTTL(getCurrentMonthKey(), Duration.ofDays(365));
+    }
+
+    /**
+     * 오늘의 상위 N개 제품을 조회합니다.
+     * 
+     * @param key Redis 키
+     * @param topN 상위 N개
+     * @return 상위 N개 제품의 Set
+     */
+    public Set<ZSetOperations.TypedTuple<String>> getTopProducts(String key, int topN) {
+        return redisTemplate.opsForZSet()
+            .reverseRangeWithScores(key, 0, topN - 1);
+    }
+
+    /**
+     * 오늘의 상위 N개 제품을 조회하기 위한 Redis 키를 생성합니다.
+     * 
+     * @param topN 상위 N개
+     * @return Redis 키
+     */
+    public String getTodayKey() {
+        return "product:order:daily:" + LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE); // yyyyMMdd
+    }
+
+    /**
+     * 이번주의 상위 N개 제품을 조회하기 위한 Redis 키를 생성합니다.
+     * 
+     * @return Redis 키
+     */
+    public String getCurrentWeekKey() {
+        LocalDate now = LocalDate.now();
+        WeekFields weekFields = WeekFields.ISO;
+        int weekNumber = now.get(weekFields.weekOfWeekBasedYear());
+        int year = now.get(weekFields.weekBasedYear());
+        return "product:order:weekly:" + String.format("%d%02d", year, weekNumber);
+    }
+
+    /**
+     * 이번 달의 상위 N개 제품을 조회하기 위한 Redis 키를 생성합니다.
+     * 
+     * @return Redis 키
+     */
+    public String getCurrentMonthKey() {
+        return "product:order:monthly:" + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMM")); // yyyyMM
+    }
+
+    /**
+     * Redis 키에 TTL을 설정합니다.
+     * 
+     * @param key Redis 키
+     * @param ttl TTL 기간
+     */
+    private void setTTL(String key, Duration ttl) {
+        redisTemplate.expire(key, ttl);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/usercoupon/UserCoupon.java
+++ b/src/main/java/kr/hhplus/be/server/usercoupon/UserCoupon.java
@@ -1,0 +1,33 @@
+package kr.hhplus.be.server.usercoupon;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "user_coupons")
+@Getter
+@Setter
+public class UserCoupon {
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @Column(nullable = false)
+  private Long userId;
+  @Column(nullable = false)
+  private Long couponId;
+  @Column(nullable = false, length = 10)
+  private String status; // "ISSUED", "USED", "EXPIRED"
+  @Column(nullable = false)
+  private LocalDateTime issuedAt;
+  @Column(nullable = false)
+  private LocalDateTime validTo;
+  @Column(nullable = true)
+  private LocalDateTime usedAt;
+}

--- a/src/main/java/kr/hhplus/be/server/usercoupon/UserCouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/usercoupon/UserCouponRepository.java
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.usercoupon;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
+}

--- a/src/main/java/kr/hhplus/be/server/usercoupon/UserCouponService.java
+++ b/src/main/java/kr/hhplus/be/server/usercoupon/UserCouponService.java
@@ -1,0 +1,36 @@
+package kr.hhplus.be.server.usercoupon;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+
+/* 
+ * 사용자 쿠폰 서비스
+ * 
+ * 사용자 쿠폰 발급 로직을 처리하는 서비스입니다.
+ */
+@Service
+public class UserCouponService {
+  private final UserCouponRepository userCouponRepository;
+
+  public UserCouponService(UserCouponRepository userCouponRepository) {
+    this.userCouponRepository = userCouponRepository;
+  }
+
+  /**
+   * 사용자에게 쿠폰을 발급합니다.
+   * 
+   * @param userId 발급받는 사용자 ID
+   * @param couponId 발급할 쿠폰 ID
+   * @param validTo 쿠폰 유효 날짜
+   */
+  public void issueUserCoupon(Long userId, Long couponId, LocalDateTime validTo) {
+    UserCoupon userCoupon = new UserCoupon();
+    userCoupon.setUserId(userId);
+    userCoupon.setCouponId(couponId);
+    userCoupon.setStatus("ISSUED");
+    userCoupon.setIssuedAt(LocalDateTime.now());
+    userCoupon.setValidTo(validTo);
+    userCouponRepository.save(userCoupon);
+  }
+}

--- a/src/test/java/kr/hhplus/be/server/coupon/CouponServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/coupon/CouponServiceTest.java
@@ -1,0 +1,98 @@
+package kr.hhplus.be.server.coupon;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import kr.hhplus.be.server.usercoupon.UserCouponService;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 쿠폰 서비스 테스트
+ * 
+ * 쿠폰 발급 로직을 검증하는 단위 테스트입니다.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CouponServiceTest {
+  @Mock
+  private CouponRepository couponRepository;
+
+  @Mock
+  private UserCouponService userCouponService;
+
+  @InjectMocks
+  private CouponService couponService;
+
+  /**
+   * 테스트용 쿠폰 객체 생성
+   * 
+   * @return Coupon 객체
+   */
+  private Coupon createCoupon() throws Exception {
+    Coupon mockCoupon = new Coupon(
+      "COUPON-TEST1",
+      "Test Coupon 1",
+      new BigDecimal("1000"),
+      10,
+      LocalDateTime.now(),
+      LocalDateTime.now().plusDays(30)
+    );
+    Field idField = Coupon.class.getDeclaredField("id");
+    idField.setAccessible(true);
+    idField.set(mockCoupon, 1L);
+    return mockCoupon;
+  }
+
+  /**
+   * 쿠폰 발급 테스트
+   */
+  @Test
+  public void testIssueCoupon() throws Exception {
+    // Given
+    Coupon mockCoupon = createCoupon();
+
+    // When
+    when(couponRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(mockCoupon));
+
+    // Then
+    couponService.issueCoupon(1L, 1L);
+    assertThat(mockCoupon.getIssuedQuantity()).isEqualTo(1);
+    verify(userCouponService).issueUserCoupon(
+      eq(1L),   // userId
+      eq(1L),   // couponId
+      eq(mockCoupon.getValidTo())   // 유효기간
+  );
+  }
+
+  /**
+   * 발급 가능한 쿠폰이 존재하지 않을 경우 예외 발생 테스트
+   */
+  @Test
+  public void testIssueCoupon_ExceedingLimit() throws Exception {
+    // Given
+    Coupon mockCoupon = createCoupon();
+    mockCoupon.issue();
+
+    // When
+    when(couponRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(mockCoupon));
+
+    // Then
+    try {
+      couponService.issueCoupon(1L, 1L);
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage()).isEqualTo("쿠폰 발급 한도를 초과했습니다.");
+    }
+  }
+
+}

--- a/src/test/java/kr/hhplus/be/server/order/ProductOrderRankingServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/order/ProductOrderRankingServiceTest.java
@@ -1,0 +1,75 @@
+package kr.hhplus.be.server.order;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import kr.hhplus.be.server.order.usecase.ProductOrderRankingService;
+
+/**
+ * 이 테스트는 Redis를 사용하여 제품 주문 순위를 매기는 서비스의 기능을 검증합니다.
+ */
+@Testcontainers
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ProductOrderRankingServiceTest {
+
+  @Container
+  static GenericContainer<?> redis = new GenericContainer<>("redis:7")
+    .withExposedPorts(6379);
+
+  @DynamicPropertySource
+  static void overrideProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.redis.host", redis::getHost);
+    registry.add("spring.redis.port", () -> redis.getMappedPort(6379));
+  }
+
+  @Autowired
+  private ProductOrderRankingService productOrderRankingService;
+
+  /**
+   * 제품 주문 순위 기능을 테스트합니다.
+   * - 제품 ID를 사용하여 점수를 증가시키고
+   * - 오늘의 상위 3개 제품을 조회하여 올바른 순위가 매겨졌는지 검증합니다.
+   */
+  @Test
+  public void testIncreaseProductScore() {
+    // Given
+    String productId1 = "1";
+    String productId2 = "2";
+    String productId3 = "3";
+
+    // When
+    productOrderRankingService.increaseProductScore(productId1);
+    productOrderRankingService.increaseProductScore(productId2);
+    productOrderRankingService.increaseProductScore(productId2);
+    productOrderRankingService.increaseProductScore(productId2);
+    productOrderRankingService.increaseProductScore(productId3);
+
+    // Then
+    String todayKey = productOrderRankingService.getTodayKey();
+    Set<ZSetOperations.TypedTuple<String>> top3ProductsToday = productOrderRankingService.getTopProducts(todayKey, 3);
+    System.out.println("=== Top 3 Products Today ===");
+    top3ProductsToday.forEach(tuple -> {
+      System.out.println("Product ID: " + tuple.getValue() + ", Score: " + tuple.getScore());
+    });
+
+    // Assertions 
+    List<String> expectedTopProducts = List.of(productId2, productId3, productId1);
+    List<String> actualTopProducts = top3ProductsToday.stream()
+        .map(ZSetOperations.TypedTuple::getValue)
+        .toList();
+    Assertions.assertEquals(expectedTopProducts, actualTopProducts);
+  }
+
+}


### PR DESCRIPTION
### **커밋 설명**
Redis 기반 가장 많이 주문한 상품 랭킹 설계 : 8039c01e456058e9b7fc816b0e533a0f0c12bd7f
Redis 기반 가장 많이 주문한 상품 랭킹 구현 : 977306f928ede7e14798c56895b566ee27fe3b25, 4f4f79b4c3300f33dd06cfe08157a73773be75d7
선착순 쿠폰 발급 (2주차 선택과제 - 비즈니스 로직 개발 및 단위 테스트 작성):  b88650da9ded006872b33c61c317ed3d72da26eb, 8af2e6905d5dbd89a39e9542adfa68a1e7bc23ad

---
### **리뷰 받고 싶은 내용(질문)**
- 리뷰 포인트 1: 랭킹 구현에 개선 필요한 점 있는지 피드백 부탁드립니다. (서비스로는 구현을 해두었는데, 주문 로직에서 호출하여 통합적으로 테스트 하는 데까지는 시간이 부족했습니다. 레디스를 사용하는 관점에서 실무에서는 어떤 식으로 통합 테스트를 하는지 궁금합니다.)
- 리뷰 포인트 2: 2주차 선택과제였던 선착순 쿠폰 로직을 일부 추가했습니다. 쿠폰과 사용자 쿠폰 도메인을 나누어 서비스로 만든 측면에서 적합한지 피드백 부탁드립니다. (목표는 레디스를 활용하는 것까지 해보는 것이었는데 시간 이슈로 진행한 부분만 커밋하였습니다.)
<!-- - 코드 리뷰에서 피드백 받고 싶은 포인트가 있다면 추가로 작성해주세요
  
  좋은 예:
  - 커밋 : 동시성 테스트 코드 d93ji3 
  - 내용 `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  
  - 커밋 : 동시성 처리 c83845 / 혹은 파일명
  - 내용 : 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---

### **과제 셀프 피드백**
✅ 랭킹 설계
✅ 랭킹 구현
✅ 이전 주차 진행 못했던 선착순 쿠폰 구현
❌ 비동기 구현

### 기술적 성장
- 캐싱이라는 관점에서만 레디스를 알고 있었는데 레디스의 다른 이점들을 이해하고 활용하게 되었다.
<!-- 예시
- 새로 학습한 개념
- 기존 지식의 재발견/심화
- 구현 과정에서의 기술적 도전과 해결
-->
